### PR TITLE
fix: Mismatched check with blackboard value

### DIFF
--- a/addons/FluentBehaviourTree/BehaviourTree/Nodes/Leaves/CommonConditions/BlackboardValueCheckBehaviourNode.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/Nodes/Leaves/CommonConditions/BlackboardValueCheckBehaviourNode.cs
@@ -17,7 +17,7 @@ public partial class BlackboardValueCheckBehaviourNode : ConditionBehaviourNode 
                 GD.PrintErr($"Missing blackboard property {blackboardPropertyName}");
                 return false;
             }
-            return expectedValue.Equals(value);
+            return expectedValue.Obj != null && expectedValue.Obj.Equals(value.Obj);
         });
     }
 }


### PR DESCRIPTION
Simple issue with blackboard condition not unwrapping raw variant value during equality check.