### PR TITLE
fix(debug-tab): Unregistered trees are now removed correctly

### DIFF
--- a/addons/FluentBehaviourTree/BehaviourTree/BehaviourTree.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/BehaviourTree.cs
@@ -28,13 +28,22 @@ public partial class BehaviourTree : Node {
     public required Node3D treeOwner;
 
     /**
-     * Properties bound to the behaviour tree
+     * A hard coded blackboard value that determines if a behaviour tree can be interrupted via <see cref="Interrupt"/>
+     */
+    public static readonly string BB_PROP_CAN_INTERUPT = "CAN_INTERRUPT";
+
+    /**
+     * Properties bound to the behaviour tree. Includes defaults.
      */
     [Export]
-    public Godot.Collections.Dictionary<string, Variant> blackboard =
-        new Godot.Collections.Dictionary<string, Variant>();
+    public Godot.Collections.Dictionary<string, Variant> blackboard = new() {
+        // Default interrupts to true. Allows leaves to conditionally enable/disable interrupts 
+        [BB_PROP_CAN_INTERUPT] = true
+    };
 
     public IBehaviour<GodotBehaviourContext> behaviourTree { get; private set; }
+
+    private string debuggerId;
 
     public override void _Ready() {
         base._Ready();
@@ -47,6 +56,7 @@ public partial class BehaviourTree : Node {
         // Don't "end" branch since it's the root
         AddBranch(builder, behaviourNodes, false);
         behaviourTree = builder.Build();
+        debuggerId = $"{Owner.Name}-{Owner.GetInstanceId()}";
         // Once built, register with debugger
         BehaviourTreeDebugRegistrar.RegisterTree(treeOwner, this);
     }
@@ -58,8 +68,10 @@ public partial class BehaviourTree : Node {
             return;
         }
 
-        behaviourTree.Tick(new GodotBehaviourContext((float)delta, treeOwner, blackboard));
-        BehaviourTreeDebugRegistrar.UpdateTree(treeOwner, this);
+        if (!IsQueuedForDeletion()) {
+            behaviourTree.Tick(new GodotBehaviourContext((float)delta, treeOwner, blackboard));
+            BehaviourTreeDebugRegistrar.UpdateTree(treeOwner, this);
+        }
     }
 
     public override void _Notification(int what) {
@@ -97,16 +109,20 @@ public partial class BehaviourTree : Node {
      * Restart the behaviour tree from the top. Useful when, for example Player input demands the BT be recalculated from the start for hit stun/death branches.
      */
     public void Interrupt() {
-        behaviourTree.Reset();
+        if (blackboard[BB_PROP_CAN_INTERUPT].AsBool()) {
+            // GD.Print($"{Owner.Name} - BT Interrupted");
+            behaviourTree.Reset();
+        }
     }
 
     /**
      * Build a variant-compatible dictionary for the debugger from the root node. Required since Godot handles
      * editor-application interactions through the networking interface via messaging, which only supports variants.
+     * <param name="debuggerMessage">Includes debugger message for potential troubleshooting of debug tab</param>
      * <seealso cref="GetNodeDebuggerData"/>
      */
-    public Dictionary GetTreeDebuggerData() {
-        return GetNodeDebuggerData(0, behaviourTree);
+    public Dictionary GetTreeDebuggerData(string debuggerMessage) {
+        return GetNodeDebuggerData(debuggerMessage, 0, behaviourTree);
     }
 
     /**
@@ -134,30 +150,41 @@ public partial class BehaviourTree : Node {
      *      }
      *  }
      * </code>
+     * <param name="debuggerMessage">Includes debugger message for potential troubleshooting of debug tab</param>
+     * <param name="depth"></param>
+     * <param name="behaviourNode"></param>
      */
-    private Dictionary GetNodeDebuggerData(int depth, IBehaviour<GodotBehaviourContext> behaviourNode) {
-        Dictionary nodeDebugMapping = new Dictionary();
+    private Dictionary GetNodeDebuggerData(string debuggerMessage,
+        int depth,
+        IBehaviour<GodotBehaviourContext> behaviourNode) {
+        var nodeDebugMapping = new Dictionary();
         nodeDebugMapping["depth"] = depth;
-        nodeDebugMapping["name"] = depth == 0 ? $"{Owner.Name}-{Owner.GetInstanceId()}" : behaviourNode.Name;
+        nodeDebugMapping["name"] = depth == 0 ? debuggerId : behaviourNode.Name;
         nodeDebugMapping["status"] = (int)behaviourNode.Status;
+
 
         // Only the root will have the blackboard 
         if (depth == 0) {
-            nodeDebugMapping["blackboard"] = blackboard;
+            nodeDebugMapping.Add("blackboard", blackboard);
         }
 
         var childDepth = depth + 1;
 
-        Array<Dictionary> children = new Array<Dictionary>();
-        if (behaviourNode is CompositeBehaviour<GodotBehaviourContext> compositeBehaviour) {
-            foreach (var child in compositeBehaviour.Children) {
-                children.Add(GetNodeDebuggerData(childDepth, child));
+        var children = new Array<Dictionary>();
+
+        switch (behaviourNode) {
+            case CompositeBehaviour<GodotBehaviourContext> compositeBehaviour:
+            {
+                foreach (var child in compositeBehaviour.Children) {
+                    children.Add(GetNodeDebuggerData(debuggerMessage, childDepth, child));
+                }
+                break;
             }
+            case DecoratorBehaviour<GodotBehaviourContext> decoratorBehaviour:
+                children.Add(GetNodeDebuggerData(debuggerMessage, depth, behaviourNode));
+                break;
         }
 
-        if (behaviourNode is DecoratorBehaviour<GodotBehaviourContext> decoratorBehaviour) {
-            children.Add(GetNodeDebuggerData(childDepth, decoratorBehaviour.Child));
-        }
         nodeDebugMapping["childNodes"] = children;
 
         return nodeDebugMapping;

--- a/addons/FluentBehaviourTree/BehaviourTree/BehaviourTree.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/BehaviourTree.cs
@@ -28,18 +28,11 @@ public partial class BehaviourTree : Node {
     public required Node3D treeOwner;
 
     /**
-     * A hard coded blackboard value that determines if a behaviour tree can be interrupted via <see cref="Interrupt"/>
-     */
-    public static readonly string BB_PROP_CAN_INTERUPT = "CAN_INTERRUPT";
-
-    /**
-     * Properties bound to the behaviour tree. Includes defaults.
+     * Properties bound to the behaviour tree
      */
     [Export]
-    public Godot.Collections.Dictionary<string, Variant> blackboard = new() {
-        // Default interrupts to true. Allows leaves to conditionally enable/disable interrupts 
-        [BB_PROP_CAN_INTERUPT] = true
-    };
+    public Godot.Collections.Dictionary<string, Variant> blackboard =
+        new Godot.Collections.Dictionary<string, Variant>();
 
     public IBehaviour<GodotBehaviourContext> behaviourTree { get; private set; }
 
@@ -68,10 +61,8 @@ public partial class BehaviourTree : Node {
             return;
         }
 
-        if (!IsQueuedForDeletion()) {
-            behaviourTree.Tick(new GodotBehaviourContext((float)delta, treeOwner, blackboard));
-            BehaviourTreeDebugRegistrar.UpdateTree(treeOwner, this);
-        }
+        behaviourTree.Tick(new GodotBehaviourContext((float)delta, treeOwner, blackboard));
+        BehaviourTreeDebugRegistrar.UpdateTree(treeOwner, this);
     }
 
     public override void _Notification(int what) {
@@ -109,10 +100,7 @@ public partial class BehaviourTree : Node {
      * Restart the behaviour tree from the top. Useful when, for example Player input demands the BT be recalculated from the start for hit stun/death branches.
      */
     public void Interrupt() {
-        if (blackboard[BB_PROP_CAN_INTERUPT].AsBool()) {
-            // GD.Print($"{Owner.Name} - BT Interrupted");
-            behaviourTree.Reset();
-        }
+        behaviourTree.Reset();
     }
 
     /**

--- a/addons/FluentBehaviourTree/BehaviourTree/Debugging/BehaviourTreeDebugRegistrar.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/Debugging/BehaviourTreeDebugRegistrar.cs
@@ -1,6 +1,5 @@
 ﻿using Godot;
 using Godot.Collections;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 namespace fluent_behaviour_tree.addons.FluentBehaviourTree.BehaviourTree.Debugging;
 

--- a/addons/FluentBehaviourTree/BehaviourTree/Debugging/BehaviourTreeDebugRegistrar.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/Debugging/BehaviourTreeDebugRegistrar.cs
@@ -1,5 +1,6 @@
 ﻿using Godot;
 using Godot.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 namespace fluent_behaviour_tree.addons.FluentBehaviourTree.BehaviourTree.Debugging;
 
@@ -34,7 +35,8 @@ public partial class BehaviourTreeDebugRegistrar : Node {
     public static void RegisterTree(Node owner, BehaviourTree tree) {
         Instance.registeredTrees[GetReadableTreeKey(owner)] = tree;
         if (CanSendMessage()) {
-            var messageParams = new Array([tree.GetTreeDebuggerData()]);
+            var messageParams =
+                new Array([tree.GetTreeDebuggerData(FluentBehaviourTreeDebugger.MESSAGE_REGISTER_TREE)]);
             EngineDebugger.SendMessage(FluentBehaviourTreeDebugger.MESSAGE_REGISTER_TREE, messageParams);
         }
     }
@@ -42,15 +44,17 @@ public partial class BehaviourTreeDebugRegistrar : Node {
     public static void UpdateTree(Node owner, BehaviourTree tree) {
         Instance.registeredTrees[GetReadableTreeKey(owner)] = tree;
         if (CanSendMessage()) {
-            var messageParams = new Array([tree.GetTreeDebuggerData()]);
+            var messageParams = new Array([tree.GetTreeDebuggerData(FluentBehaviourTreeDebugger.MESSAGE_UPDATE_TREE)]);
             EngineDebugger.SendMessage(FluentBehaviourTreeDebugger.MESSAGE_UPDATE_TREE, messageParams);
         }
     }
 
     public static void UnregisterTree(Node owner, BehaviourTree tree) {
         Instance.registeredTrees.Remove(GetReadableTreeKey(owner));
+        // Send dictionary of current tree to debugger for removal
         if (CanSendMessage()) {
-            var messageParams = new Array([tree.GetTreeDebuggerData()]);
+            var messageParams =
+                new Array([tree.GetTreeDebuggerData(FluentBehaviourTreeDebugger.MESSAGE_UNREGISTER_TREE)]);
             EngineDebugger.SendMessage(FluentBehaviourTreeDebugger.MESSAGE_UNREGISTER_TREE, messageParams);
         }
     }


### PR DESCRIPTION
Fixed an issue where trees were not being unregistered with the "unregister" event.
And thus, clogging up the debugger tab in a heavily populated scene without cleanup.