### PR TITLE
feat: Added blackboard interrupt toggle default

### DIFF
--- a/addons/FluentBehaviourTree/BehaviourTree/BehaviourTree.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/BehaviourTree.cs
@@ -28,11 +28,18 @@ public partial class BehaviourTree : Node {
     public required Node3D treeOwner;
 
     /**
-     * Properties bound to the behaviour tree
+     * A hard coded blackboard value that determines if a behaviour tree can be interrupted via <see cref="Interrupt"/>
+     */
+    public static readonly string BB_PROP_CAN_INTERUPT = "CAN_INTERRUPT";
+
+    /**
+     * Properties bound to the behaviour tree. Includes defaults.
      */
     [Export]
-    public Godot.Collections.Dictionary<string, Variant> blackboard =
-        new Godot.Collections.Dictionary<string, Variant>();
+    public Godot.Collections.Dictionary<string, Variant> blackboard = new() {
+        // Default interrupts to true. Allows leaves to conditionally enable/disable interrupts 
+        [BB_PROP_CAN_INTERUPT] = true
+    };
 
     public IBehaviour<GodotBehaviourContext> behaviourTree { get; private set; }
 
@@ -97,7 +104,9 @@ public partial class BehaviourTree : Node {
      * Restart the behaviour tree from the top. Useful when, for example Player input demands the BT be recalculated from the start for hit stun/death branches.
      */
     public void Interrupt() {
-        behaviourTree.Reset();
+        if (blackboard[BB_PROP_CAN_INTERUPT].AsBool()) {
+            behaviourTree.Reset();
+        }
     }
 
     /**
@@ -136,14 +145,16 @@ public partial class BehaviourTree : Node {
      * </code>
      */
     private Dictionary GetNodeDebuggerData(int depth, IBehaviour<GodotBehaviourContext> behaviourNode) {
-        Dictionary nodeDebugMapping = new Dictionary();
-        nodeDebugMapping["depth"] = depth;
-        nodeDebugMapping["name"] = depth == 0 ? $"{Owner.Name}-{Owner.GetInstanceId()}" : behaviourNode.Name;
-        nodeDebugMapping["status"] = (int)behaviourNode.Status;
+        Dictionary nodeDebugMapping = new Dictionary {
+            ["depth"] = depth,
+            ["name"] = depth == 0 ? $"{Owner.Name}-{Owner.GetInstanceId()}"
+                : behaviourNode.Name,
+            ["status"] = (int)behaviourNode.Status,
+        };
 
         // Only the root will have the blackboard 
         if (depth == 0) {
-            nodeDebugMapping["blackboard"] = blackboard;
+            nodeDebugMapping.Add("blackboard", blackboard);
         }
 
         var childDepth = depth + 1;


### PR DESCRIPTION
Not all trees want to be interrupted and reset since this can cause unintended side effects on rigid trees.

So a default blackbaord value was added to allow for some behaviour trees to ignore this. This is especially useful when creating generic logic for enemies or other NPCs.

_This will be enabled by default._ If there's a reasonable argument otherwise, feel free to make a case in a new issue.