### PR TITLE
fix(decorators): Addressed issues with debugger and added node warnings

### DIFF
--- a/addons/FluentBehaviourTree/BehaviourTree/BehaviourTree.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/BehaviourTree.cs
@@ -178,8 +178,10 @@ public partial class BehaviourTree : Node {
                 break;
             }
             case DecoratorBehaviour<GodotBehaviourContext> decoratorBehaviour:
-                children.Add(GetNodeDebuggerData(debuggerMessage, depth, behaviourNode));
+            {
+                children.Add(GetNodeDebuggerData(debuggerMessage, childDepth, decoratorBehaviour.Child));
                 break;
+            }
         }
 
         nodeDebugMapping["childNodes"] = children;

--- a/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/CooldownDecoratorBehaviourNode.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/CooldownDecoratorBehaviourNode.cs
@@ -5,6 +5,7 @@ namespace fluent_behaviour_tree.addons.FluentBehaviourTree.BehaviourTree.Nodes.D
 /**
  * After node is composite or leaf is successful, wait N milliseconds before trying again
  */
+[Tool]
 [GlobalClass]
 public partial class CooldownDecoratorBehaviourNode : DecoratorBehaviourNode {
 
@@ -12,6 +13,6 @@ public partial class CooldownDecoratorBehaviourNode : DecoratorBehaviourNode {
     public int cooldownTimeInMilliseconds;
 
     public override void BuildNode(FluentBuilder<GodotBehaviourContext> builder) {
-        builder.Cooldown(Name,  cooldownTimeInMilliseconds);
+        builder.Cooldown(Name, cooldownTimeInMilliseconds);
     }
 }

--- a/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/DecoratorBehaviourNode.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/DecoratorBehaviourNode.cs
@@ -1,9 +1,37 @@
 ﻿using Godot;
+using System.Collections.Generic;
 namespace fluent_behaviour_tree.addons.FluentBehaviourTree.BehaviourTree.Nodes.Decorators;
 
 /**
  * A base node for decorators
  */
 [Icon("res://addons/FluentBehaviourTree/BehaviourTree/Nodes/icons/BTDecorator.svg")]
+[Tool]
 [GlobalClass]
-public abstract partial class DecoratorBehaviourNode : BehaviourNode {}
+public abstract partial class DecoratorBehaviourNode : BehaviourNode {
+
+    /**
+     * Decorators only support a single child node. Effectively acting as a "modifier" to a behaviour.
+     * Try to enforce this through the editor via warnings.
+     */
+    public override string[] _GetConfigurationWarnings() {
+        var warnings = new List<string>();
+
+        var childCount = GetChildCount();
+        switch (childCount) {
+            case > 1:
+            {
+                warnings.Add($"Expected 1 child, but found {childCount}");
+                break;
+            }
+            case 0:
+            {
+                warnings.Add("This node requires a child");
+                break;
+            }
+        }
+
+        return warnings.ToArray();
+    }
+
+}

--- a/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/FailerDecoratorBehaviourNode.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/FailerDecoratorBehaviourNode.cs
@@ -6,6 +6,7 @@ namespace fluent_behaviour_tree.addons.FluentBehaviourTree.BehaviourTree.Nodes.D
  * Always fail the child node
  */
 [Icon("res://addons/FluentBehaviourTree/BehaviourTree/Nodes/icons/BTDecoratorFail.svg")]
+[Tool]
 [GlobalClass]
 public partial class FailerDecoratorBehaviourNode : DecoratorBehaviourNode {
 

--- a/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/InverterDecoratorBehaviourNode.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/InverterDecoratorBehaviourNode.cs
@@ -10,11 +10,11 @@ namespace fluent_behaviour_tree.addons.FluentBehaviourTree.BehaviourTree.Nodes.D
  *  FAILED -> SUCCESS
  */
 [Icon("res://addons/FluentBehaviourTree/BehaviourTree/Nodes/icons/BTDecoratorNot.svg")]
+[Tool]
 [GlobalClass]
 public partial class InverterDecoratorBehaviourNode : DecoratorBehaviourNode {
 
-    public override void
-        BuildNode(FluentBuilder<GodotBehaviourContext> builder) {
+    public override void BuildNode(FluentBuilder<GodotBehaviourContext> builder) {
         builder.Invert(Name);
     }
 }

--- a/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/RandomDecoratorBehaviourNode.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/RandomDecoratorBehaviourNode.cs
@@ -6,6 +6,7 @@ namespace fluent_behaviour_tree.addons.FluentBehaviourTree.BehaviourTree.Nodes.D
  * Has a n% chance to execute the child nodes
  */
 [Icon("res://addons/FluentBehaviourTree/BehaviourTree/Nodes/icons/BTCompositeRandomSelector.svg")]
+[Tool]
 [GlobalClass]
 public partial class RandomDecoratorBehaviourNode : DecoratorBehaviourNode {
 

--- a/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/RateLimiterDecoratorBehaviourNode.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/RateLimiterDecoratorBehaviourNode.cs
@@ -6,6 +6,7 @@ namespace fluent_behaviour_tree.addons.FluentBehaviourTree.BehaviourTree.Nodes.D
  * Cache the output of a completed call for N milliseconds. Where the cache is dirties and the composite or leaf will be called again
  */
 [Icon("res://addons/FluentBehaviourTree/BehaviourTree/Nodes/icons/BTDecoratorLimiter.svg")]
+[Tool]
 [GlobalClass]
 public partial class RateLimiterDecoratorBehaviourNode : DecoratorBehaviourNode {
 

--- a/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/RepeatDecoratorBehaviourNode.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/RepeatDecoratorBehaviourNode.cs
@@ -5,6 +5,7 @@ namespace fluent_behaviour_tree.addons.FluentBehaviourTree.BehaviourTree.Nodes.D
 /**
  * Repeat the child node N times, as given by node input
  */
+[Tool]
 [GlobalClass]
 public partial class RepeatDecoratorBehaviourNode : DecoratorBehaviourNode {
 

--- a/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/SucceederDecoratorBehaviourNode.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/SucceederDecoratorBehaviourNode.cs
@@ -3,6 +3,7 @@ using Godot;
 namespace fluent_behaviour_tree.addons.FluentBehaviourTree.BehaviourTree.Nodes.Decorators;
 
 [Icon("res://addons/FluentBehaviourTree/BehaviourTree/Nodes/icons/BTDecoratorSucceed.svg")]
+[Tool]
 [GlobalClass]
 public partial class SucceederDecoratorBehaviourNode : DecoratorBehaviourNode {
 

--- a/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/TimeLimitDecoratorBehaviourNode.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/TimeLimitDecoratorBehaviourNode.cs
@@ -5,6 +5,7 @@ namespace fluent_behaviour_tree.addons.FluentBehaviourTree.BehaviourTree.Nodes.D
 /**
  * Decorator has N time in milliseconds for it's child nodes to complete, otherwise, fail the nodes
  */
+[Tool]
 [GlobalClass]
 public partial class TimeLimitDecoratorBehaviourNode : DecoratorBehaviourNode {
 

--- a/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/UntilFailureDecoratorBehaviourNode.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/UntilFailureDecoratorBehaviourNode.cs
@@ -6,6 +6,7 @@ namespace fluent_behaviour_tree.addons.FluentBehaviourTree.BehaviourTree.Nodes.D
  * Repeat until child nodes succeeds
  */
 [Icon("res://addons/FluentBehaviourTree/BehaviourTree/Nodes/icons/BTDecoratorFail.svg")]
+[Tool]
 [GlobalClass]
 public partial class UntilFailureDecoratorBehaviourNode : DecoratorBehaviourNode {
 

--- a/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/UntilSuccessDecoratorBehaviourNode.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/Nodes/Decorators/UntilSuccessDecoratorBehaviourNode.cs
@@ -6,6 +6,7 @@ namespace fluent_behaviour_tree.addons.FluentBehaviourTree.BehaviourTree.Nodes.D
  * Repeat until child nodes succeeds
  */
 [Icon("res://addons/FluentBehaviourTree/BehaviourTree/Nodes/icons/BTDecoratorSucceed.svg")]
+[Tool]
 [GlobalClass]
 public partial class UntilSuccessDecoratorBehaviourNode : DecoratorBehaviourNode {
 


### PR DESCRIPTION
Fixed a frankly dumb bug where decorators would cause a stack overflow due to missed recursion in the debug panel.

Also added a warning to decorator nodes for if there are no or more than one child node.