### PR TITLE
fix: Added additional check before unregistering tree in debugger

### DIFF
--- a/addons/FluentBehaviourTree/BehaviourTree/Debugging/BehaviourTreeDebuggerPanel.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/Debugging/BehaviourTreeDebuggerPanel.cs
@@ -166,6 +166,10 @@ public partial class BehaviourTreeDebuggerPanel : PanelContainer {
         UpdateBlackboardTable(behaviourTree["blackboard"].AsGodotDictionary());
     }
 
+    public bool CanUnregister() {
+        return treeArray.Count > 0;
+    }
+
     public string GetTreeName(Dictionary tree) {
         return tree.GetValueOrDefault("name", "").AsString();
     }

--- a/addons/FluentBehaviourTree/BehaviourTree/Debugging/FluentBehaviourTreeDebugger.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/Debugging/FluentBehaviourTreeDebugger.cs
@@ -24,7 +24,7 @@ public partial class FluentBehaviourTreeDebugger : EditorDebuggerPlugin {
         session.Started += () => debuggerPanel.Start();
         session.Stopped += () => debuggerPanel.Stop();
 
-        
+
         GD.Print("Adding debugger session tab");
 
         debuggerPanel.Name = "Behaviour Tree Live View";
@@ -49,6 +49,10 @@ public partial class FluentBehaviourTreeDebugger : EditorDebuggerPlugin {
         }
         if (message == MESSAGE_UNREGISTER_TREE) {
             var behaviourTree = data[0].AsGodotDictionary();
+            if (!debuggerPanel.CanUnregister()) {
+                GD.PushWarning("No behaviour trees registered");
+                return true;
+            }
             debuggerPanel.TreeUnregistered(behaviourTree);
             return true;
         }


### PR DESCRIPTION
On exit, the debug panel would flood the console with errors about failing to unregister behaviour trees. This is likely because the `Stop` command has already cleared the array containing these.

So rather than going through and ensuring these stay in sync on shutdown, we will receive the message, but do a check for if there is any behaviour trees to remove. If not, push a warning and acknowledge the message as received.