### PR TITLE
fix(export): Added TOOLS check for exports

### DIFF
--- a/addons/FluentBehaviourTree/BehaviourTree/BehaviourTree.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/BehaviourTree.cs
@@ -58,7 +58,9 @@ public partial class BehaviourTree : Node {
         behaviourTree = builder.Build();
         debuggerId = $"{Owner.Name}-{Owner.GetInstanceId()}";
         // Once built, register with debugger
+        #if TOOLS
         BehaviourTreeDebugRegistrar.RegisterTree(treeOwner, this);
+        #endif
     }
 
     public override void _Process(double delta) {
@@ -69,12 +71,16 @@ public partial class BehaviourTree : Node {
         }
 
         behaviourTree.Tick(new GodotBehaviourContext((float)delta, treeOwner, blackboard));
+        #if TOOLS
         BehaviourTreeDebugRegistrar.UpdateTree(treeOwner, this);
+        #endif
     }
 
     public override void _Notification(int what) {
         if (what == NotificationPredelete) {
+            #if TOOLS
             BehaviourTreeDebugRegistrar.UnregisterTree(treeOwner, this);
+            #endif
         }
     }
 

--- a/addons/FluentBehaviourTree/BehaviourTree/Debugging/BehaviourTreeDebugRegistrar.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/Debugging/BehaviourTreeDebugRegistrar.cs
@@ -1,4 +1,5 @@
-﻿using Godot;
+﻿#if TOOLS
+using Godot;
 using Godot.Collections;
 using System.Linq;
 namespace fluent_behaviour_tree.addons.FluentBehaviourTree.BehaviourTree.Debugging;
@@ -76,3 +77,4 @@ public partial class BehaviourTreeDebugRegistrar : Node {
         return EngineDebugger.IsActive() && !Engine.IsEditorHint() && OS.HasFeature("editor");
     }
 }
+#endif

--- a/addons/FluentBehaviourTree/BehaviourTree/Debugging/BehaviourTreeDebuggerPanel.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/Debugging/BehaviourTreeDebuggerPanel.cs
@@ -1,4 +1,5 @@
-﻿using Godot;
+﻿#if TOOLS
+using Godot;
 using Godot.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -176,3 +177,4 @@ public partial class BehaviourTreeDebuggerPanel : PanelContainer {
         return tree.GetValueOrDefault("name", "").AsString();
     }
 }
+#endif

--- a/addons/FluentBehaviourTree/BehaviourTree/Debugging/FluentBehaviourTreeDebugger.cs
+++ b/addons/FluentBehaviourTree/BehaviourTree/Debugging/FluentBehaviourTreeDebugger.cs
@@ -1,4 +1,5 @@
-﻿using Godot;
+﻿#if TOOLS
+using Godot;
 using System.Collections.Generic;
 using Array = Godot.Collections.Array;
 namespace fluent_behaviour_tree.addons.FluentBehaviourTree.BehaviourTree.Debugging;
@@ -75,3 +76,4 @@ public partial class FluentBehaviourTreeDebugger : EditorDebuggerPlugin {
         return false;
     }
 }
+#endif


### PR DESCRIPTION
Ran into issues exporting a project. The debug tooling caused the msbuild to fail.
Some checks for debug tools were inserted such that they won't be included for builds.